### PR TITLE
Packaging of Android bits

### DIFF
--- a/android/hybris/Android.mk
+++ b/android/hybris/Android.mk
@@ -32,7 +32,7 @@ LOCAL_CFLAGS += \
 endif
 
 LOCAL_C_INCLUDES := \
-	$(UPAPI_PATH)/include
+	$(UPAPI_PATH)/src
 
 ifeq ($(IS_ANDROID_8),true)
 LOCAL_SRC_FILES += \

--- a/android/hybris/biometry_fp_hidl_for_hybris.cpp
+++ b/android/hybris/biometry_fp_hidl_for_hybris.cpp
@@ -15,7 +15,7 @@
  *
  * Authored by: Erfan Abdi <erfangplus@gmail.com>
  */
-#include <biometry/hardware/biometry.h>
+#include <biometry.h>
 
 #include <pthread.h>
 #include <string.h>

--- a/rpm/copy-hal.sh
+++ b/rpm/copy-hal.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+OUT_DEVICE=${HABUILD_DEVICE:-$DEVICE}
+
+if [ ! -f ./out/target/product/${OUT_DEVICE}/system/lib/libbiometry_fp_api.so ]; then
+    echo "Please build Fingerprint support as per HADK instructions"
+    exit 1
+fi
+
+pkg=droidmedia-"${1:-0.0.0}"
+fold=$(dirname "$0")/../out
+rm -rf $fold
+mkdir $fold
+cp ./out/target/product/${OUT_DEVICE}/system/lib/libbiometry_fp_api.so $fold
+ls -lh $fold
+

--- a/rpm/copy-hal.sh
+++ b/rpm/copy-hal.sh
@@ -9,7 +9,6 @@ if [ ! -f ./out/target/product/${OUT_DEVICE}/system/lib/libbiometry_fp_api.so ];
     exit 1
 fi
 
-pkg=droidmedia-"${1:-0.0.0}"
 fold=$(dirname "$0")/../out
 rm -rf $fold
 mkdir $fold

--- a/rpm/droid-biometry-fp.spec
+++ b/rpm/droid-biometry-fp.spec
@@ -1,0 +1,31 @@
+%define strip /bin/true
+%define __requires_exclude  ^.*$
+%define __find_requires     %{nil}
+%global debug_package       %{nil}
+%define __provides_exclude_from ^.*$
+%define device_rpm_architecture_string armv7hl
+%define _target_cpu %{device_rpm_architecture_string}
+
+Name:     droid-biometry-fp
+Summary:  Android Biometry FingerPrint library
+Version:  0.0.1
+Release:  %(date +'%%Y%%m%%d%%H%%M')
+Group:    Kernel/Linux Kernel
+License:  GPLv3
+Source0:  out/libbiometry_fp_api.so
+
+%description
+%{summary}
+
+%build
+pwd
+ls -lh
+
+%install
+
+mkdir -p $RPM_BUILD_ROOT/usr/libexec/droid-hybris/system/lib
+cp out/libbiometry_fp_api.so $RPM_BUILD_ROOT/usr/libexec/droid-hybris/system/lib
+
+%files
+%defattr(-,root,root,-)
+/usr/libexec/droid-hybris/system/lib/libbiometry_fp_api.so


### PR DESCRIPTION
This brings packaging of Android bits into RPMs

For docs and how to use:

In HADK:
```
git clone https://github.com/piggz/sailfish-fpd-community.git hybris/mw/sailfish-fpd-community
source build/envsetup.sh
export USE_CCACHE=1
lunch aosp_$DEVICE-user
make libbiometry_fp_api_32
hybris/mw/sailfish-fpd-community/rpm/copy-hal.sh
```

In SDK:

```
rpm/dhd/helpers/build_packages.sh --build=hybris/mw/sailfish-fpd-community --spec=rpm/droid-biometry-fp.spec --do-not-install
```

I have not added dependency of sailfish-fpd-community on droid-biometry-fp. I suggest to add it later, will file the issue to be sure we don't forget it.

Fixes #3