### PR TITLE
Lock to the client stateful state

### DIFF
--- a/src/fpdcommunity.cpp
+++ b/src/fpdcommunity.cpp
@@ -265,8 +265,8 @@ void FPDCommunity::slot_succeeded(uint32_t finger)
     emit Added(m_addingFinger);
     m_addingFinger = "";
     saveFingers();
+    emit ListChanged();
     setState(FPSTATE_IDLE);
-    enumerate();
 }
 
 void FPDCommunity::slot_failed(const QString &message)
@@ -275,7 +275,6 @@ void FPDCommunity::slot_failed(const QString &message)
 
     if (!(m_state == FPSTATE_IDENTIFYING && message == "FINGER_NOT_RECOGNIZED")) {
         setState(FPSTATE_IDLE);
-        enumerate();
     }
 }
 
@@ -323,8 +322,9 @@ void FPDCommunity::slot_removed(uint32_t finger)
     QString f = m_fingerMap[finger];
     emit Removed(f);
     m_fingerMap.remove(finger);
+    saveFingers();
+    emit ListChanged();
     setState(FPSTATE_IDLE);
-    enumerate();
 }
 
 void FPDCommunity::slot_authenticated(uint32_t finger)
@@ -350,9 +350,9 @@ void FPDCommunity::slot_cancelIdentify()
 void FPDCommunity::slot_enumerated()
 {
     qDebug() << Q_FUNC_INFO;
-    setState(FPSTATE_IDLE);
     loadFingers();
     emit ListChanged();
+    setState(FPSTATE_IDLE);
 }
 
 void FPDCommunity::setState(FPDCommunity::State newState)

--- a/src/fpdcommunity.cpp
+++ b/src/fpdcommunity.cpp
@@ -192,6 +192,7 @@ int FPDCommunity::Abort()
     }
     m_androidFP.cancel();
     m_cancelTimer.stop();
+    emit Aborted();
     setState(FPSTATE_IDLE);
     return FPREPLY_STARTED;
 }
@@ -273,7 +274,12 @@ void FPDCommunity::slot_failed(const QString &message)
 {
     qDebug() << Q_FUNC_INFO << message;
 
-    if (!(m_state == FPSTATE_IDENTIFYING && message == "FINGER_NOT_RECOGNIZED")) {
+    emit ErrorInfo(message); // always report error via signal
+    if (m_state == FPSTATE_IDENTIFYING && message == "FINGER_NOT_RECOGNIZED")
+        return; // giving a chance to try another finger
+
+    if (m_state != FPSTATE_IDLE) {
+        emit Failed();
         setState(FPSTATE_IDLE);
     }
 }
@@ -344,6 +350,7 @@ void FPDCommunity::slot_cancelIdentify()
 {
     qDebug() << Q_FUNC_INFO;
     m_androidFP.cancel();
+    emit Failed();
     setState(FPSTATE_IDLE);
 }
 

--- a/src/fpdcommunity.h
+++ b/src/fpdcommunity.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QMetaEnum>
 #include <QTimer>
+#include <QDBusMessage>
 
 #include "androidfp.h"
 
@@ -98,13 +99,14 @@ public:
     /* ========================================================================= *
      * FINGERPRINT_DAEMON_DBUS_SERVICE (API Version 1)
      * ========================================================================= */
-    Q_INVOKABLE int Enroll(const QString &finger);
-    Q_INVOKABLE int Identify();
+    Q_INVOKABLE int Enroll(const QString &finger, const QDBusMessage &message);
+    Q_INVOKABLE int Identify(const QDBusMessage &message);
     Q_INVOKABLE QString GetState();
     Q_INVOKABLE QStringList GetAll(); //Returns list of templates in store
-    Q_INVOKABLE int Abort();
-    Q_INVOKABLE int Verify();
-    Q_INVOKABLE int Remove(const QString &finger);
+    Q_INVOKABLE int Abort(const QDBusMessage &message);
+    Q_INVOKABLE int Verify(const QDBusMessage &message);
+    Q_INVOKABLE int Remove(const QString &finger, const QDBusMessage &message);
+    Q_INVOKABLE void Clear(const QDBusMessage &message);
 
     Q_SIGNAL void Added(const QString &finger);
     Q_SIGNAL void Removed(const QString &finger);
@@ -121,8 +123,6 @@ public:
 
     /* ========================================================================= */
 
-    Q_INVOKABLE void Clear();
-
 private slots:
     void slot_enrollProgress(float pc);
     void slot_succeeded(uint32_t finger);
@@ -134,11 +134,13 @@ private slots:
     void slot_enumerated();
 
 private:
+    void abort();
     void enumerate();
 
 private:
     AndroidFP m_androidFP;
     bool m_dbusRegistered = false;
+    QString m_dbusCaller;
     State m_state = FPSTATE_IDLE;
     AcquiredState m_acquired = FPACQUIRED_UNSPECIFIED;
     QString m_addingFinger;

--- a/src/fpdcommunity.h
+++ b/src/fpdcommunity.h
@@ -3,6 +3,8 @@
 
 #include <QObject>
 #include <QMetaEnum>
+#include <QTimer>
+
 #include "androidfp.h"
 
 #define SERVICE_NAME "org.sailfishos.fingerprint1"
@@ -141,6 +143,7 @@ private:
     AcquiredState m_acquired = FPACQUIRED_UNSPECIFIED;
     QString m_addingFinger;
     QMap<uint32_t, QString> m_fingerMap;
+    QTimer m_cancelTimer;
 
     void setState(State newState);
     void registerDBus();


### PR DESCRIPTION
This PR addresses housekeeping issues of the daemon:

- ensures that the cancel timer is called only when needed and will not cancel some operation just by chance
- loads and adjusts fingerprint id <-> fingerprint name map on start and updates it from successful additions and removals. This allows to avoid calling enroll after operations and move to idle immediately
- emit failure signals before switching to idle. that way failure is associated with the state leading to it.
- allow to cancel operations only by clients that requested particular operation.

As a result of these changes, device reboots got resolved as well (#10). Now I can add several FPs without any issues and reboots. I guess reboot was caused by something on SFOS as it was getting unexpected replied from the daemon.

Fixes #18 and #10