### PR TITLE
Clear fingerprint map on removal of all fingerprints

### DIFF
--- a/src/androidfp.cpp
+++ b/src/androidfp.cpp
@@ -158,6 +158,8 @@ void AndroidFP::removeCallback(uint32_t finger, uint32_t remaining)
     qDebug() << Q_FUNC_INFO << finger << remaining;
 
     if ((finger == m_removingFinger || m_removingFinger == 0) && remaining == 0) {
+        if (m_removingFinger == 0)
+            finger = 0;
         emit removed(finger);
         m_removingFinger = 0;
     }

--- a/src/androidfp.cpp
+++ b/src/androidfp.cpp
@@ -76,6 +76,7 @@ void AndroidFP::enroll(uid_t user_id)
 void AndroidFP::remove(uid_t finger)
 {
     qDebug() << Q_FUNC_INFO << finger;
+    m_removingFinger = finger;
     UHardwareBiometryRequestStatus ret = u_hardware_biometry_remove(m_biometry, 0, finger);
     if (ret != SYS_OK) {
         failed(QString::fromUtf8(IntToStringRequestStatus(ret).data()));

--- a/src/fpdcommunity.cpp
+++ b/src/fpdcommunity.cpp
@@ -382,9 +382,16 @@ void FPDCommunity::slot_acquired(int info)
 void FPDCommunity::slot_removed(uint32_t finger)
 {
     qDebug() << Q_FUNC_INFO << finger;
-    QString f = m_fingerMap[finger];
-    emit Removed(f);
-    m_fingerMap.remove(finger);
+    if (finger != 0) {
+        QString f = m_fingerMap[finger];
+        emit Removed(f);
+        m_fingerMap.remove(finger);
+    } else {
+        QStringList values = m_fingerMap.values();
+        for (auto f: values)
+            emit Removed(f);
+        m_fingerMap.clear();
+    }
     saveFingers();
     emit ListChanged();
     setState(FPSTATE_IDLE);


### PR DESCRIPTION
This ensures that we handle Clear operation correctly and keep the cached fingerprint map as it should be. On remove(0), after final fingerprint removal, the map is cleared. 
