### PR TITLE
Introduce user-dependent storage of fingerprint data

### DIFF
--- a/src/androidfp.cpp
+++ b/src/androidfp.cpp
@@ -59,10 +59,12 @@ QString AndroidFP::getDefaultGroupPath(uint32_t uid)
 {
     util::AndroidPropertyStore store;
     std::string api_level = store.get("ro.product.first_api_level");
-    if (api_level.empty())
+    if (api_level.empty()) {
       api_level = store.get("ro.build.version.sdk");
-    if (atoi(api_level.c_str()) <= 27)
+    }
+    if (atoi(api_level.c_str()) <= 27) {
       return QStringLiteral("/data/system/users/%1/fpdata").arg(uid);
+    }
     return QStringLiteral("/data/vendor_de/%1/fpdata").arg(uid);
 }
 
@@ -76,9 +78,9 @@ void AndroidFP::setGroup(uint32_t gid, const QString &storePath)
         qWarning() << "Cannot set empty active group path";
         failed(QStringLiteral("Cannot set empty active group path"));
         return;
-    } else {
-        std::strncpy(path, storePath.toLocal8Bit().data(), sizeof(path));
     }
+
+    std::strncpy(path, storePath.toLocal8Bit().data(), sizeof(path));
     path[ sizeof(path)-1 ] = 0;
     ret = u_hardware_biometry_setActiveGroup(m_biometry, gid, path);
 

--- a/src/androidfp.h
+++ b/src/androidfp.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QList>
+#include <QString>
 
 #include "biometry.h"
 
@@ -11,6 +12,7 @@ class AndroidFP : public QObject
     Q_OBJECT
 public:
     explicit AndroidFP(QObject *parent = nullptr);
+    void setGroup(uint32_t gid, const QString &storePath);
     void enroll(uid_t user_id);
     void remove(uid_t finger);
     void cancel();
@@ -18,6 +20,8 @@ public:
     void enumerate();
     void clear();
     QList<uint32_t> fingerprints() const;
+
+    static QString getDefaultGroupPath(uint32_t uid);
 
 signals:
     void failed(const QString& message);

--- a/src/fpdcommunity.cpp
+++ b/src/fpdcommunity.cpp
@@ -103,13 +103,15 @@ static bool makePath(const char* path, const char* user = nullptr, const char* g
     qDebug() << Q_FUNC_INFO << path << user << group << permissions;
 
     QFileInfo fi(path);
-    if (fi.exists())
+    if (fi.exists()) {
         return true;
+    }
 
     QString leaf = fi.fileName();
     QDir dir = fi.absoluteDir();
-    if (!makePath(dir.path().toLocal8Bit().data(), user, group, permissions))
+    if (!makePath(dir.path().toLocal8Bit().data(), user, group, permissions)) {
         return false;
+    }
 
     if (!dir.mkdir(leaf)) {
         qWarning() << "Failed to create directory" << path;
@@ -121,8 +123,10 @@ static bool makePath(const char* path, const char* user = nullptr, const char* g
         return false;
     }
 
-    if (user != nullptr && group != nullptr)
+    if (user != nullptr && group != nullptr) {
       return do_chown(path, user, group);
+    }
+
     return true;
 }
 
@@ -159,7 +163,7 @@ void FPDCommunity::saveFingers()
 
     QFile fingerprintFile(m_fingerDatabasePath);
 
-    if (!fingerprintFile.open(QIODevice::WriteOnly)){
+    if (!fingerprintFile.open(QIODevice::WriteOnly)) {
         qWarning() << "Could not write " << m_fingerDatabasePath;
         return;
     }

--- a/src/fpdcommunity.cpp
+++ b/src/fpdcommunity.cpp
@@ -7,6 +7,12 @@
 #include <QDir>
 #include <QDataStream>
 #include <QFile>
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <grp.h>
+
 #define FINGERPRINT_PATH "/var/lib/sailfish-fpd-community/"
 #define FINGERPRINT_FILE "fingerprints.db"
 
@@ -27,13 +33,8 @@ FPDCommunity::FPDCommunity()
     m_cancelTimer.setInterval(30000);
     connect(&m_cancelTimer, &QTimer::timeout, this, &FPDCommunity::slot_cancelIdentify);
 
-    //Create folder to store fingerprint names
-    if (!(QDir().mkpath(FINGERPRINT_PATH))) {
-        qWarning() << "Unable to create " << FINGERPRINT_PATH;
-    }
-
-    // fingers are enumerated and loaded after that
-    enumerate();
+    // set current user - nemo for now
+    setUser(100000);
     registerDBus();
 }
 
@@ -65,15 +66,101 @@ void FPDCommunity::registerDBus()
     }
 }
 
+// Code from https://stackoverflow.com/a/37489754/11848012
+// with minor modifications
+bool do_chown(const char *file_path, const char *user_name,
+              const char *group_name)
+{
+    uid_t          uid;
+    gid_t          gid;
+    struct passwd *pwd;
+    struct group  *grp;
+
+    pwd = getpwnam(user_name);
+    if (pwd == nullptr) {
+        qWarning() << "Failed to get user id for" << user_name;
+        return false;
+    }
+    uid = pwd->pw_uid;
+
+    grp = getgrnam(group_name);
+    if (grp == nullptr) {
+        qWarning() << "Failed to get group id for" << group_name;
+        return false;
+    }
+    gid = grp->gr_gid;
+
+    if (chown(file_path, uid, gid) == -1) {
+        qWarning() << "Failed to chown for" << file_path;
+        return false;
+    }
+    return true;
+}
+
+static bool makePath(const char* path, const char* user = nullptr, const char* group = nullptr,
+                     QFileDevice::Permissions permissions = QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner)
+{
+    qDebug() << Q_FUNC_INFO << path << user << group << permissions;
+
+    QFileInfo fi(path);
+    if (fi.exists())
+        return true;
+
+    QString leaf = fi.fileName();
+    QDir dir = fi.absoluteDir();
+    if (!makePath(dir.path().toLocal8Bit().data(), user, group, permissions))
+        return false;
+
+    if (!dir.mkdir(leaf)) {
+        qWarning() << "Failed to create directory" << path;
+        return false;
+    }
+
+    if (!QFile::setPermissions(path, permissions))  {
+        qWarning() << "Failed to set permissions" << path;
+        return false;
+    }
+
+    if (user != nullptr && group != nullptr)
+      return do_chown(path, user, group);
+    return true;
+}
+
+void FPDCommunity::setUser(uint32_t uid)
+{
+    qDebug() << Q_FUNC_INFO << uid;
+
+    // path for android store
+    QString andrPath = AndroidFP::getDefaultGroupPath(uid);
+
+    // create path if missing and set expected permissions / ownership
+    if (!makePath(andrPath.toLocal8Bit().data(), "system", "system")) {
+        qWarning() << "Unable to create Android store" << andrPath;
+    }
+
+    // path for storing string<->uint fp id map
+    QDir fpDir(QStringLiteral(FINGERPRINT_PATH "/%1").arg(uid));
+    if (!makePath(fpDir.absolutePath().toLocal8Bit().data())) {
+        qWarning() << "Unable to create FPD store" << fpDir.absolutePath();
+    }
+
+    m_fingerDatabasePath = fpDir.absoluteFilePath(FINGERPRINT_FILE);
+
+    // always setting group id to 0
+    m_androidFP.setGroup(0, andrPath);
+
+    // fingers are enumerated and loaded after that
+    enumerate();
+}
+
 void FPDCommunity::saveFingers()
 {
     qDebug() << Q_FUNC_INFO;
 
-    QString filename = FINGERPRINT_PATH FINGERPRINT_FILE;
-    QFile fingerprintFile(filename);
+    QFile fingerprintFile(m_fingerDatabasePath);
 
     if (!fingerprintFile.open(QIODevice::WriteOnly)){
-        qWarning() << "Could not write " << filename;
+        qWarning() << "Could not write " << m_fingerDatabasePath;
         return;
     }
 
@@ -86,13 +173,12 @@ void FPDCommunity::loadFingers()
 {
     qDebug() << Q_FUNC_INFO;
 
-    QString filename = FINGERPRINT_PATH FINGERPRINT_FILE;
-    QFile fingerprintFile(filename);
+    QFile fingerprintFile(m_fingerDatabasePath);
     QDataStream in(&fingerprintFile);
     in.setVersion(QDataStream::Qt_5_6);
 
     if (!fingerprintFile.open(QIODevice::ReadOnly)) {
-        qInfo() << "Could not read the file:" << filename << "Error string:" << fingerprintFile.errorString();
+        qInfo() << "Could not read the file:" << m_fingerDatabasePath << "Error string:" << fingerprintFile.errorString();
         qInfo() << "Assuming empty fingerprint map";
         m_fingerMap.clear();
     } else {

--- a/src/fpdcommunity.h
+++ b/src/fpdcommunity.h
@@ -138,16 +138,21 @@ private slots:
 private:
     void abort();
     void enumerate();
+    void setUser(uint32_t uid);
 
 private:
     AndroidFP m_androidFP;
+    QTimer m_cancelTimer;
+
     bool m_dbusRegistered = false;
     QString m_dbusCaller;
+
+    QString m_fingerDatabasePath;
+    QMap<uint32_t, QString> m_fingerMap;
+
     State m_state = FPSTATE_IDLE;
     AcquiredState m_acquired = FPACQUIRED_UNSPECIFIED;
     QString m_addingFinger;
-    QMap<uint32_t, QString> m_fingerMap;
-    QTimer m_cancelTimer;
 
     void setState(State newState);
     void registerDBus();


### PR DESCRIPTION
This introduces required changes for multiuser setup #17. It assumes that all works as it should. In particular, it

* creates user-dedicated FP storage folder for Android 
* creates user-dedicated FP storage folder for Sailfish map 
* introduces API to swap between users in future (internally)

If we start hitting issues, we will have to add options (CMD line?) to restrict location of the database used by Android. 

When multiuser will arrive, then we will see how to deal with the broken devices. Question is in Android DB. Such as if we can just move the databases into some dedicated spot, or if we have to share the same database by all users. But it would be clear when we start getting problematic devices.

Please review and test.