### PR TITLE
Only trust an enumeration that came back from the HAL

### DIFF
--- a/src/androidfp.cpp
+++ b/src/androidfp.cpp
@@ -53,6 +53,20 @@ AndroidFP::AndroidFP(QObject *parent) : QObject(parent), m_biometry(u_hardware_b
     fp_params.enumerate_cb = enumerate_cb;
     fp_params.context = this;
     u_hardware_biometry_setNotify(m_biometry, &fp_params);
+
+    // Fallback for HALs that never answer enumerate(); see there.
+    m_enumerateTimeout.setSingleShot(true);
+    m_enumerateTimeout.setInterval(3000);
+    connect(&m_enumerateTimeout, &QTimer::timeout, this, [this]() {
+        // A HAL that answers when it holds templates and says nothing here
+        // holds none. Before its first reply silence proves nothing.
+        if (m_halAnswersEnumerate)
+            m_enumerationAuthoritative = true;
+        qWarning() << "AndroidFP: enumerate produced no callback, assuming"
+                   << m_fingers.count() << "enrolled fingerprint(s);"
+                   << (m_enumerationAuthoritative ? "authoritative" : "not authoritative");
+        emit enumerated();
+    });
 }
 
 QString AndroidFP::getDefaultGroupPath(uint32_t uid)
@@ -131,10 +145,20 @@ void AndroidFP::enumerate()
 {
     qDebug() << Q_FUNC_INFO;
     m_fingers.clear();
+    m_enumerationAuthoritative = false;
+
+    // Some HALs never invoke the callback when nothing is enrolled, which would
+    // leave the daemon stuck in FPSTATE_ENUMERATING; the timeout ends the round.
+    m_enumerateTimeout.stop();
     UHardwareBiometryRequestStatus ret = u_hardware_biometry_enumerate(m_biometry);
     if (ret != SYS_OK) {
+        // Finish the round anyway so callers are not left waiting, but leave it
+        // non-authoritative: some HALs fail a call that in fact succeeded.
         failed(QString::fromUtf8(IntToStringRequestStatus(ret).data()));
+        emit enumerated();
+        return;
     }
+    m_enumerateTimeout.start();
 }
 
 void AndroidFP::clear()
@@ -153,13 +177,22 @@ QList<uint32_t> AndroidFP::fingerprints() const
     return m_fingers;
 }
 
+bool AndroidFP::enumerationAuthoritative() const
+{
+    return m_enumerationAuthoritative;
+}
+
 void AndroidFP::enumerateCallback(uint32_t finger, uint32_t remaining)
 {
     qDebug() << Q_FUNC_INFO << finger << remaining;
+    m_enumerateTimeout.stop();
+    m_halAnswersEnumerate = true;
     if (finger != 0)
         m_fingers.push_back(finger);
-    if (remaining == 0)
+    if (remaining == 0) {
+        m_enumerationAuthoritative = true;
         emit enumerated();
+    }
 }
 
 void AndroidFP::enrollCallback(uint32_t finger, uint32_t remaining)

--- a/src/androidfp.h
+++ b/src/androidfp.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QList>
 #include <QString>
+#include <QTimer>
 
 #include "biometry.h"
 
@@ -20,6 +21,9 @@ public:
     void enumerate();
     void clear();
     QList<uint32_t> fingerprints() const;
+    // False when the round was ended by the timeout or a failed call: an empty
+    // fingerprints() then means "not known", not "the store is empty".
+    bool enumerationAuthoritative() const;
 
     static QString getDefaultGroupPath(uint32_t uid);
 
@@ -34,6 +38,7 @@ signals:
 
 private:
     void enumerateCallback(uint32_t finger, uint32_t remaining);
+    QTimer m_enumerateTimeout;
     void enrollCallback(uint32_t finger, uint32_t remaining);
     void removeCallback(uint32_t finger, uint32_t remaining);
     void acquiredCallback(UHardwareBiometryFingerprintAcquiredInfo info);
@@ -52,6 +57,10 @@ private:
     float m_enrollRemaining = 0.0;
     uint32_t m_removingFinger = 0;
     QList<uint32_t> m_fingers;
+    bool m_enumerationAuthoritative = false;
+    // Set once the HAL has replied to any enumerate, which is what makes a
+    // later silent round meaningful.
+    bool m_halAnswersEnumerate = false;
 };
 
 #endif // ANDROIDFP_H

--- a/src/fpdcommunity.cpp
+++ b/src/fpdcommunity.cpp
@@ -191,6 +191,20 @@ void FPDCommunity::loadFingers()
 
     QList<uint32_t> enumeratedFingers = m_androidFP.fingerprints();
 
+    // Only reconcile when the HAL actually told us what is in the store. On
+    // karatep enumerate() fails outright whenever templates exist, so an empty
+    // list means "unknown". Reconciling against it would drop every finger
+    // loaded above and saveFingers() would make that permanent: the names
+    // vanish while the templates stay in the FPC trustlet, the UI shows nothing
+    // enrolled, and re-enrolling the same finger is then rejected by the TEE
+    // with "do_enroll finger already enrolled" / ERROR_VENDOR: 1.
+    if (!m_androidFP.enumerationAuthoritative()) {
+        qWarning() << "Enumeration unavailable; keeping" << m_fingerMap.size()
+                   << "stored finger(s) as-is and skipping reconcile";
+        qDebug() << "Loaded finger map (unreconciled):" << m_fingerMap;
+        return;
+    }
+
     //Check each of the loaded prints to ensure it was loaded from the store
     QList<uint32_t> keys = m_fingerMap.keys();
     for (int i = 0; i < keys.size(); ++i) {


### PR DESCRIPTION
`fingerprints()` was read as "the store is empty" whenever it was empty, however the round ended. Two HAL behaviours break that: some never invoke the callback when nothing is enrolled, leaving the daemon stuck in `FPSTATE_ENUMERATING`; others fail `enumerate()` from a call that in fact succeeded — one returns the template count from the vendor library while the HIDL service maps any non-zero return to an error:

```
fpc_fingerprint_hal: fpc_enumerate indices_count 2
...fingerprint@2.0-service: An unknown error returned from fingerprint vendor library: 2
```

A timeout ends the round in the first case, the failed call finishes it in the second, and neither result is trustworthy — so `AndroidFP` now exposes `enumerationAuthoritative()`, and `loadFingers()` refuses to reconcile persisted names against a list that never arrived. Pruning there would destroy the user's names while the templates remain in the store.

One exception: once the HAL has answered an enumerate, a later silent round does mean an empty store, because it replies when it holds templates. Without that an empty store can never be confirmed, and removing the last enrolled template can never be verified.

Tested on Lenovo K6 Note (FPC1020, hybris-18.1).
