### PR TITLE
Do not adopt templates left by a previous installation

### DIFF
--- a/src/androidfp.cpp
+++ b/src/androidfp.cpp
@@ -53,6 +53,20 @@ AndroidFP::AndroidFP(QObject *parent) : QObject(parent), m_biometry(u_hardware_b
     fp_params.enumerate_cb = enumerate_cb;
     fp_params.context = this;
     u_hardware_biometry_setNotify(m_biometry, &fp_params);
+
+    // Fallback for HALs that never answer enumerate(); see there.
+    m_enumerateTimeout.setSingleShot(true);
+    m_enumerateTimeout.setInterval(3000);
+    connect(&m_enumerateTimeout, &QTimer::timeout, this, [this]() {
+        // A HAL that answers when it holds templates and says nothing here
+        // holds none. Before its first reply silence proves nothing.
+        if (m_halAnswersEnumerate)
+            m_enumerationAuthoritative = true;
+        qWarning() << "AndroidFP: enumerate produced no callback, assuming"
+                   << m_fingers.count() << "enrolled fingerprint(s);"
+                   << (m_enumerationAuthoritative ? "authoritative" : "not authoritative");
+        emit enumerated();
+    });
 }
 
 QString AndroidFP::getDefaultGroupPath(uint32_t uid)
@@ -131,10 +145,20 @@ void AndroidFP::enumerate()
 {
     qDebug() << Q_FUNC_INFO;
     m_fingers.clear();
+    m_enumerationAuthoritative = false;
+
+    // Some HALs never invoke the callback when nothing is enrolled, which would
+    // leave the daemon stuck in FPSTATE_ENUMERATING; the timeout ends the round.
+    m_enumerateTimeout.stop();
     UHardwareBiometryRequestStatus ret = u_hardware_biometry_enumerate(m_biometry);
     if (ret != SYS_OK) {
+        // Finish the round anyway so callers are not left waiting, but leave it
+        // non-authoritative: some HALs fail a call that in fact succeeded.
         failed(QString::fromUtf8(IntToStringRequestStatus(ret).data()));
+        emit enumerated();
+        return;
     }
+    m_enumerateTimeout.start();
 }
 
 void AndroidFP::clear()
@@ -153,13 +177,22 @@ QList<uint32_t> AndroidFP::fingerprints() const
     return m_fingers;
 }
 
+bool AndroidFP::enumerationAuthoritative() const
+{
+    return m_enumerationAuthoritative;
+}
+
 void AndroidFP::enumerateCallback(uint32_t finger, uint32_t remaining)
 {
     qDebug() << Q_FUNC_INFO << finger << remaining;
+    m_enumerateTimeout.stop();
+    m_halAnswersEnumerate = true;
     if (finger != 0)
         m_fingers.push_back(finger);
-    if (remaining == 0)
+    if (remaining == 0) {
+        m_enumerationAuthoritative = true;
         emit enumerated();
+    }
 }
 
 void AndroidFP::enrollCallback(uint32_t finger, uint32_t remaining)

--- a/src/androidfp.h
+++ b/src/androidfp.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QList>
 #include <QString>
+#include <QTimer>
 
 #include "biometry.h"
 
@@ -20,6 +21,9 @@ public:
     void enumerate();
     void clear();
     QList<uint32_t> fingerprints() const;
+    // False when the round was ended by the timeout or a failed call: an empty
+    // fingerprints() then means "not known", not "the store is empty".
+    bool enumerationAuthoritative() const;
 
     static QString getDefaultGroupPath(uint32_t uid);
 
@@ -34,6 +38,7 @@ signals:
 
 private:
     void enumerateCallback(uint32_t finger, uint32_t remaining);
+    QTimer m_enumerateTimeout;
     void enrollCallback(uint32_t finger, uint32_t remaining);
     void removeCallback(uint32_t finger, uint32_t remaining);
     void acquiredCallback(UHardwareBiometryFingerprintAcquiredInfo info);
@@ -52,6 +57,10 @@ private:
     float m_enrollRemaining = 0.0;
     uint32_t m_removingFinger = 0;
     QList<uint32_t> m_fingers;
+    bool m_enumerationAuthoritative = false;
+    // Set once the HAL has replied to any enumerate, which is what makes a
+    // later silent round meaningful.
+    bool m_halAnswersEnumerate = false;
 };
 
 #endif // ANDROIDFP_H

--- a/src/fpdcommunity.cpp
+++ b/src/fpdcommunity.cpp
@@ -181,6 +181,9 @@ void FPDCommunity::loadFingers()
     QDataStream in(&fingerprintFile);
     in.setVersion(QDataStream::Qt_5_6);
 
+    // No map file at all means this installation has never enrolled anything.
+    const bool everEnrolled = fingerprintFile.exists();
+
     if (!fingerprintFile.open(QIODevice::ReadOnly)) {
         qInfo() << "Could not read the file:" << m_fingerDatabasePath << "Error string:" << fingerprintFile.errorString();
         qInfo() << "Assuming empty fingerprint map";
@@ -216,6 +219,17 @@ void FPDCommunity::loadFingers()
             qWarning() << "Unknown fingerprint found, adding to the list:" << k;
             m_fingerMap[k] = QStringLiteral("Unknown %1").arg(k);
         }
+    }
+
+    // The map lives in the rootfs, the templates in the Android store, which
+    // outlives it: with no map at all these are from a previous installation.
+    // They stay in the map only until finishRemoval() confirms the removal.
+    if (!everEnrolled && !m_fingerMap.isEmpty()) {
+        qWarning() << "No finger map at" << m_fingerDatabasePath << "but"
+                   << m_fingerMap.size() << "template(s) enrolled; they are left"
+                   << "over from a previous installation, removing";
+        m_clearOrphans = true;
+        return;
     }
 
     //Save after load incase any were removed or added
@@ -574,6 +588,14 @@ void FPDCommunity::slot_enumerated()
     }
 
     loadFingers();
+
+    if (m_clearOrphans) {
+        m_clearOrphans = false;
+        setState(FPSTATE_REMOVING);
+        m_androidFP.clear();
+        return;
+    }
+
     emit ListChanged();
     setState(FPSTATE_IDLE);
 }

--- a/src/fpdcommunity.cpp
+++ b/src/fpdcommunity.cpp
@@ -191,6 +191,20 @@ void FPDCommunity::loadFingers()
 
     QList<uint32_t> enumeratedFingers = m_androidFP.fingerprints();
 
+    // Only reconcile when the HAL actually told us what is in the store. On
+    // karatep enumerate() fails outright whenever templates exist, so an empty
+    // list means "unknown". Reconciling against it would drop every finger
+    // loaded above and saveFingers() would make that permanent: the names
+    // vanish while the templates stay in the FPC trustlet, the UI shows nothing
+    // enrolled, and re-enrolling the same finger is then rejected by the TEE
+    // with "do_enroll finger already enrolled" / ERROR_VENDOR: 1.
+    if (!m_androidFP.enumerationAuthoritative()) {
+        qWarning() << "Enumeration unavailable; keeping" << m_fingerMap.size()
+                   << "stored finger(s) as-is and skipping reconcile";
+        qDebug() << "Loaded finger map (unreconciled):" << m_fingerMap;
+        return;
+    }
+
     //Check each of the loaded prints to ensure it was loaded from the store
     QList<uint32_t> keys = m_fingerMap.keys();
     for (int i = 0; i < keys.size(); ++i) {

--- a/src/fpdcommunity.cpp
+++ b/src/fpdcommunity.cpp
@@ -191,13 +191,8 @@ void FPDCommunity::loadFingers()
 
     QList<uint32_t> enumeratedFingers = m_androidFP.fingerprints();
 
-    // Only reconcile when the HAL actually told us what is in the store. On
-    // karatep enumerate() fails outright whenever templates exist, so an empty
-    // list means "unknown". Reconciling against it would drop every finger
-    // loaded above and saveFingers() would make that permanent: the names
-    // vanish while the templates stay in the FPC trustlet, the UI shows nothing
-    // enrolled, and re-enrolling the same finger is then rejected by the TEE
-    // with "do_enroll finger already enrolled" / ERROR_VENDOR: 1.
+    // Never prune against a list that did not come from the HAL: the names are
+    // persisted, so saveFingers() would make an unknown result permanent.
     if (!m_androidFP.enumerationAuthoritative()) {
         qWarning() << "Enumeration unavailable; keeping" << m_fingerMap.size()
                    << "stored finger(s) as-is and skipping reconcile";
@@ -486,13 +481,60 @@ void FPDCommunity::slot_acquired(int info)
 void FPDCommunity::slot_removed(uint32_t finger)
 {
     qDebug() << Q_FUNC_INFO << finger;
+
+    // onRemoved() only says the HAL considers the operation finished, not that
+    // the template left the store, so re-enumerate before dropping the name.
+    // Fail-closed: keep the entry unless it is observed to be gone.
+
+    // A terminating onRemoved(fid=0) would start a second round that races the
+    // first and fails a removal that succeeded, so verify once per request.
+    if (m_verifyingRemoval) {
+        qDebug() << Q_FUNC_INFO << "verification already in flight; ignoring"
+                 << "additional removed callback for" << finger;
+        return;
+    }
+
+    m_removedFinger = finger;
+    m_verifyingRemoval = true;
+    m_androidFP.enumerate();
+}
+
+void FPDCommunity::finishRemoval()
+{
+    m_verifyingRemoval = false;
+    const uint32_t finger = m_removedFinger;
+    m_removedFinger = 0;
+
+    if (!m_androidFP.enumerationAuthoritative()) {
+        qWarning() << Q_FUNC_INFO << "cannot confirm removal of" << finger
+                   << "- enumeration is not authoritative; keeping the entry";
+        emit ErrorInfo(QStringLiteral("Removal could not be confirmed"));
+        emit Failed();
+        setState(FPSTATE_IDLE);
+        return;
+    }
+
+    const QList<uint32_t> present = m_androidFP.fingerprints();
+    QList<uint32_t> stillPresent;
+    for (uint32_t k : (finger == 0 ? m_fingerMap.keys() : QList<uint32_t>{finger})) {
+        if (present.contains(k))
+            stillPresent.append(k);
+    }
+
+    if (!stillPresent.isEmpty()) {
+        qWarning() << Q_FUNC_INFO << "HAL reported removal but" << stillPresent
+                   << "are still enrolled; keeping them and failing the request";
+        emit ErrorInfo(QStringLiteral("Fingerprint was not removed"));
+        emit Failed();
+        setState(FPSTATE_IDLE);
+        return;
+    }
+
     if (finger != 0) {
-        QString f = m_fingerMap[finger];
-        emit Removed(f);
+        emit Removed(m_fingerMap[finger]);
         m_fingerMap.remove(finger);
     } else {
-        QStringList values = m_fingerMap.values();
-        for (auto f: values)
+        for (const QString &f : m_fingerMap.values())
             emit Removed(f);
         m_fingerMap.clear();
     }
@@ -525,6 +567,12 @@ void FPDCommunity::slot_cancelIdentify()
 void FPDCommunity::slot_enumerated()
 {
     qDebug() << Q_FUNC_INFO;
+
+    if (m_verifyingRemoval) {
+        finishRemoval();
+        return;
+    }
+
     loadFingers();
     emit ListChanged();
     setState(FPSTATE_IDLE);

--- a/src/fpdcommunity.h
+++ b/src/fpdcommunity.h
@@ -156,6 +156,7 @@ private:
     QString m_addingFinger;
     bool m_verifyingRemoval = false;
     uint32_t m_removedFinger = 0;
+    bool m_clearOrphans = false;
 
     void setState(State newState);
     void registerDBus();

--- a/src/fpdcommunity.h
+++ b/src/fpdcommunity.h
@@ -124,6 +124,7 @@ public:
 
     /* Community DBUS API additions */
     Q_INVOKABLE void Clear(const QDBusMessage &message);
+    void finishRemoval();
 
 private slots:
     void slot_enrollProgress(float pc);
@@ -153,6 +154,8 @@ private:
     State m_state = FPSTATE_IDLE;
     AcquiredState m_acquired = FPACQUIRED_UNSPECIFIED;
     QString m_addingFinger;
+    bool m_verifyingRemoval = false;
+    uint32_t m_removedFinger = 0;
 
     void setState(State newState);
     void registerDBus();


### PR DESCRIPTION
Depends on #41 and #42 — until those merge this PR also shows their commits.

The name map lives in the Sailfish rootfs; the templates live where `setActiveGroup()` points — `/data/system/users/<uid>/fpdata` — which is outside it. That path cannot move: AOSP labels only it and `/data/vendor_de/<uid>/fpdata` in `system/sepolicy/private/file_contexts`, so anywhere else works on a permissive device and breaks on an enforcing one.

Reinstalling the OS therefore replaces the map and leaves the templates, and `loadFingers()` adopted them:

```cpp
qWarning() << "Unknown fingerprint found, adding to the list:" << k;
m_fingerMap[k] = QStringLiteral("Unknown %1").arg(k);
```

A freshly flashed device then unlocked with the previous owner's fingerprint, listed as `Unknown <id>`.

No map file at all means this rootfs has never enrolled anything, so those templates belong to no user here — remove them instead of adopting them. A map that merely lacks an entry is a desync within one installation and keeps the existing behaviour. The templates stay in the map only so `finishRemoval()` can verify the removal, and nothing is persisted until it does, so a failure is retried on the next start.

Verified on hardware (Lenovo K6 Note, FPC1020, hybris-18.1):

- stale template removed on first start, `GetAll` goes from `["Unknown 1445599621"]` to empty, `user.db` 151457 → 77 bytes;
- a real enrolment is left alone — `Loaded finger map: QMap((1395054052, "finger1"))`, no removal;
- empty store with no prior HAL reply stays non-authoritative and nothing is touched.
